### PR TITLE
fix medium-size integer formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ https://github.com/tanishiking/jpp/releases
 $ go get -u github.com/tanishiking/jpp/cmd/jpp
 ```
 
+### Develop
+```
+$ curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+$ dep ensure
+$ go test .
+
 ## jpp command
 ### Options
 - `-w`: width (default: your terminal width)

--- a/jpp.go
+++ b/jpp.go
@@ -2,6 +2,7 @@ package jpp
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -46,7 +47,7 @@ func prettyRec(b *bytes.Buffer, depth int, j gjson.Result) {
 		b.WriteString(color("false"))
 	case gjson.Number:
 		color := coloring.Number
-		b.WriteString(color("%v", j.Num))
+		b.WriteString(color(formatNum(j.Num)))
 	case gjson.String:
 		color := coloring.String
 		b.WriteString(color("\"%v\"", j.Str))
@@ -176,7 +177,7 @@ func toDoc(j gjson.Result) p.Doc {
 		return p.TextWithLength(color(str), length)
 	case gjson.Number:
 		color := coloring.Number
-		str := fmt.Sprintf("%v", j.Num)
+		str := formatNum(j.Num)
 		length := len([]rune(str))
 		return p.TextWithLength(color(str), length)
 	case gjson.String:
@@ -208,4 +209,9 @@ func allValuesAreScalar(m map[string]gjson.Result) bool {
 		}
 	}
 	return true
+}
+
+func formatNum(num float64) string {
+	data, _ := json.Marshal(num)
+	return string(data)
 }

--- a/jpp_test.go
+++ b/jpp_test.go
@@ -315,3 +315,32 @@ func TestPretty_JSONObject_TryToFitInSingleLine_Nested(t *testing.T) {
 		t.Errorf("expected: %v, actual: %v", expected, actual)
 	}
 }
+
+func TestPretty_Num(t *testing.T) {
+	var orig string
+	var actual string
+
+	orig = `{"top": 1234567890}`
+	actual, _ = jpp.Pretty(orig, "  ", 100, nil)
+	if orig != actual {
+		t.Errorf("expected: %v, actual: %v", orig, actual)
+	}
+
+	orig = `1234567890`
+	actual, _ = jpp.Pretty(orig, "  ", 100, nil)
+	if orig != actual {
+		t.Errorf("expected: %v, actual: %v", orig, actual)
+	}
+
+	orig = `1.23456789e+99`
+	actual, _ = jpp.Pretty(orig, "  ", 100, nil)
+	if orig != actual {
+		t.Errorf("expected: %v, actual: %v", orig, actual)
+	}
+
+	orig = `123.456`
+	actual, _ = jpp.Pretty(orig, "  ", 100, nil)
+	if orig != actual {
+		t.Errorf("expected: %v, actual: %v", orig, actual)
+	}
+}


### PR DESCRIPTION
I was having issues with jpp's number formatting. Values like `3360097` became `3.539976e+06`. This change uses the same float formatting logic as `encoding/json`, which seems reasonable.