### PR TITLE
Remove devtools from go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 BIN=jpp
 BUILD_OUTPUT=bin
-GO=go
 
 all: clean build
 
@@ -8,13 +7,15 @@ deps:
 	go mod vendor
 
 build: deps
-	${GO} build -o ${BUILD_OUTPUT}/${BIN} ./cmd/jpp
+	go build -o ${BUILD_OUTPUT}/${BIN} ./cmd/jpp
 
 test: deps
-	${GO} test -v ./...
+	go test -v ./...
 
+# GO111MODULE=off for dropping devtools from go.mod
+# https://github.com/golang/go/issues/30515
 lintdeps:
-	go get -u golang.org/x/lint/golint
+	GO111MODULE=off go get -u golang.org/x/lint/golint
 
 lint: lintdeps build
 	go vet
@@ -24,7 +25,7 @@ cross: build crossdeps
 	goxz -os=linux,darwin,windows -arch=386,amd64 -n $(BIN) ./cmd/jpp
 
 crossdeps:
-	go get github.com/Songmu/goxz/cmd/goxz
+	GO111MODULE=off go get github.com/Songmu/goxz/cmd/goxz
 
 clean:
 	rm -rf bin goxz vendor


### PR DESCRIPTION
This PR prevents `make lintdeps` or `make cross` to install dev dependencies into go.mod

See: https://github.com/golang/go/issues/30515